### PR TITLE
Add docker-compose.yml for running local Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  db:
+    image: postgres:10.1
+    environment:
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - 5432:5432


### PR DESCRIPTION
If you have Docker Compose installed, this lets you start a local Postgres instance with `docker-compose up` (or `docker-compose up -d` to run in the background).