### PR TITLE
Exclude unused stages from API response

### DIFF
--- a/lib/jumubase/foundation/contest_category.ex
+++ b/lib/jumubase/foundation/contest_category.ex
@@ -10,6 +10,7 @@ defmodule Jumubase.Foundation.ContestCategory do
 
     belongs_to :contest, Contest
     belongs_to :category, Category
+    has_many :performances, Jumubase.Showtime.Performance
 
     timestamps()
   end

--- a/lib/jumubase/foundation/foundation.ex
+++ b/lib/jumubase/foundation/foundation.ex
@@ -63,7 +63,13 @@ defmodule Jumubase.Foundation do
       where: c.timetables_public,
       join: h in assoc(c, :host),
       order_by: [{:desc, c.round}, h.name],
-      preload: [host: {h, :stages}, contest_categories: :category]
+      # Exclude unused stages
+      join: s in assoc(h, :stages),
+      join: cc in assoc(c, :contest_categories),
+      join: p in assoc(cc, :performances),
+      where: p.stage_id == s.id,
+      # Assign used stages manually in preload
+      preload: [host: {h, stages: s}, contest_categories: {cc, :category}]
 
     Repo.all(query)
   end

--- a/test/jumubase/foundation/foundation_test.exs
+++ b/test/jumubase/foundation/foundation_test.exs
@@ -134,18 +134,22 @@ defmodule Jumubase.FoundationTest do
       assert_ids_match_unordered Foundation.list_public_contests, [c]
     end
 
-    test "preloads the contests' hosts with stages, as well as contest categories" do
-      insert(:contest,
-        host: build(:host, stages: build_list(1, :stage)),
-        contest_categories: build_list(1, :contest_category),
-        timetables_public: true
-      )
+    test "preloads the contests' hosts with used stages, as well as contest categories" do
+      [s1, s2, _] = stages = insert_list(3, :stage)
+      host = insert(:host, stages: stages)
+      c = insert(:contest, host: host, contest_categories: [], timetables_public: true)
+      cc = insert_contest_category(c)
+
+      # Keep third stage unused
+      insert_performance(cc, stage: s1)
+      insert_performance(cc, stage: s2)
 
       [result] = Foundation.list_public_contests
       assert %Contest{
-        host: %Host{stages: [%Stage{}]},
+        host: %Host{stages: result_stages},
         contest_categories: [%ContestCategory{category: %Category{}}]
       } = result
+      assert_ids_match_unordered result_stages, [s1, s2]
     end
   end
 

--- a/test/jumubase/foundation/foundation_test.exs
+++ b/test/jumubase/foundation/foundation_test.exs
@@ -128,10 +128,20 @@ defmodule Jumubase.FoundationTest do
   end
 
   describe "list_public_contests/1" do
-    test "returns all contests with public timetables" do
-      c = insert(:contest, timetables_public: true)
-      insert(:contest, timetables_public: false)
-      assert_ids_match_unordered Foundation.list_public_contests, [c]
+    test "returns all contests with public timetables and 1+ scheduled performance" do
+      %{stages: [s]} = host_with_stage = insert(:host, stages: build_list(1, :stage))
+
+      # Matching contest
+      c1 = insert(:contest, host: host_with_stage, timetables_public: true)
+      insert_performance(c1, stage: s)
+
+      # Non-matching contests
+      insert(:contest, timetables_public: true)
+      insert(:contest, host: host_with_stage, timetables_public: true)
+      c2 = insert(:contest, host: host_with_stage, timetables_public: false)
+      insert_performance(c2, stage: s)
+
+      assert_ids_match_unordered Foundation.list_public_contests, [c1]
     end
 
     test "preloads the contests' hosts with used stages, as well as contest categories" do


### PR DESCRIPTION
The aim of this PR is to clean up the API response for `GET /api/v1/contests` as follows: The `venues` field should only contain stages that are actually used in the contest, i.e. that have associated performances from that contest.